### PR TITLE
Create separate section for audio and music tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Related projects:
       <ul>
         <li><a href="#natural-language-generation">Natural Language Generation</a></li>
         <li><a href="#natural-language-understanding">Natural Language Understanding</a></li>
-        <li><a href="#other-nlp-tasks">Other NLP tasks</a></li>
+        <li><a href="#other-nlp-tasks">Other NLP Tasks</a></li>
         <li><a href="#computer-vision">Computer Vision</a></li>
         <li><a href="#audio-and-music-tasks">Audio and Music Tasks</a></li>
         <li><a href="#web-application">Web Application</a></li>
@@ -207,6 +207,7 @@ Related projects:
 8. RWKV Based Music Generator [[project](https://github.com/asuller/RWKV-MusicGenerator)]
 9. Music Genre Classification RWKV [[project](https://github.com/AverageJoe9/Music-Genre-Classification-RWKV)]
 10. Advancing vad systems based on multi-task learning with improved model structures [[paper](https://arxiv.org/abs/2312.14860)]
+11. RWKV-based speech translation, recognition, QA, and more [[project]](https://github.com/AGENDD/RWKV-SpeechChat)
 
 ### Web Application
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@
 
 # Papers and resources for RWKV
 
-The papers are organized according to our survey: [A Survey of RWKV](https://arxiv.org/abs/2412.14847). 
+The papers are organized according to our survey: [A Survey of RWKV](https://arxiv.org/abs/2412.14847).
 
 **NOTE:** As we cannot update the arXiv paper in real time, please refer to this repo for the latest updates and the paper may be updated later. We also welcome any pull request or issues to help us make this survey perfect. Your contributions will be acknowledged in <a href="#acknowledgements">acknowledgements</a>.
 
 Related projects:
+
 - RWKV-IR: [[Exploring Real&Synthetic Dataset and Linear Attention in Image Restoration](https://arxiv.org/abs/2412.03814)]
 
 ![](imgs/framework_new.png)
@@ -32,7 +33,7 @@ Related projects:
     <li><a href="#news-and-updates">News and Updates</a></li>
     <li><a href="#rwkv">RWKV</a>
       <ul>
-        <li><a href="#rwkv-papers-and-official-repositorie">RWKV papers and official repositorie</a></li>
+        <li><a href="#rwkv-papers-and-official-repository">RWKV papers and official repository</a></li>
         <li><a href="#various-implementations">Various Implementations</a></li>
       </ul>  
     </li>
@@ -43,6 +44,7 @@ Related projects:
         <li><a href="#natural-language-understanding">Natural Language Understanding</a></li>
         <li><a href="#other-nlp-tasks">Other NLP tasks</a></li>
         <li><a href="#computer-vision">Computer Vision</a></li>
+        <li><a href="#audio-and-music-tasks">Audio and Music Tasks</a></li>
         <li><a href="#web-application">Web Application</a></li>
         <li><a href="#evaluation-of-rwkv-models">Evaluation of RWKV Models</a></li>
         <li><a href="#others">Others</a></li>
@@ -60,11 +62,11 @@ Related projects:
 
 ## RWKV
 
-### RWKV papers and official repositorie
+### RWKV papers and official repository
 
 1. RWKV: Reinventing RNNs for the Transformer Era 2023.[[paper](https://arxiv.org/abs/2305.13048)]
 2. Eagle and Finch: RWKV with Matrix-Valued States and Dynamic Recurrence 2024. [[paper](https://arxiv.org/abs/2404.05892)]
-3. RWKV official repositorie [[project](https://github.com/BlinkDL/RWKV-LM)]
+3. RWKV official repository [[project](https://github.com/BlinkDL/RWKV-LM)]
 
 ### Various Implementations
 
@@ -99,12 +101,12 @@ Related projects:
 29. Node.js implementation binding for the RWKV.cpp module [[project](https://github.com/RWKV/RWKV-cpp-node)]
 30. Native Node.js tokenizer for RWKV [[project](https://github.com/RWKV/RWKV-tokenizer-node)]
 31. Implementation of RWKV using mlx [[project](https://github.com/dc-dc-dc/mlx-rwkv)]
-32. RWKV v5,v6 LoRA Trainer on Cuda and Rocm Platform [[project](https://github.com/OpenMOSE/RWKV5-LM-LoRA)]
+32. RWKV v5, v6 LoRA Trainer on Cuda and Rocm Platform [[project](https://github.com/OpenMOSE/RWKV5-LM-LoRA)]
 33. RWKV v5, v6 infctx LoRA trainer [[project](https://github.com/OpenMOSE/RWKV-infctx-trainer-LoRA)]
 34. RWKV Infinite Context trainer [[project](https://github.com/RWKV/RWKV-infctx-trainer)]
 35. A lightweight RWKV inference platform [[project](https://github.com/OpenMOSE/RWKV-Infer)]
 36. Run RWKV V4 ONNX using the Android cpu [[project](https://github.com/ZTMIDGO/RWKV-Android)]
-37. Infere RWKV on NCNN [[project](https://github.com/MollySophia/rwkv-ncnn)]
+37. Inference RWKV on NCNN [[project](https://github.com/MollySophia/rwkv-ncnn)]
 38. Inference RWKV v5, v6 and (WIP) v7 with Qualcomm AI Engine Direct SDK [[project](https://github.com/MollySophia/rwkv-qualcomm)]
 39. JNI wrapper for rwkv.cpp [[project](https://github.com/vaccovecrana/rwkv.jni)]
 40. An RWKV6 operator designed for Keras3 [[project](https://github.com/infiy-quine/RWKV6_Keras_Operator)]
@@ -112,6 +114,7 @@ Related projects:
 42. The nanoGPT-style implementation of RWKV Language Model [[project](https://github.com/Hannibal046/nanoRWKV)]
 
 ## Applications of the RWKV model
+
 ### Natural Language Generation
 
 1. Combining information retrieval and large language models for a chatbot that generates reliable, natural-style answers. [[paper](https://ceur-ws.org/Vol-3630/LWDA2023-paper27.pdf)]
@@ -131,9 +134,6 @@ Related projects:
 15. A Telegram LLM bot [[project](https://github.com/spion/notgpt)]
 16. Chatbots based on nonebot and RWKV [[project](https://github.com/123summertime/ykkz)]
 17. Online chat rooms based on PyWebIO and RWKV models [[project](https://github.com/No-22-Github/Easy_RWKV_webui)]
-18. Android RWKV MIDI [[project](https://github.com/ZTMIDGO/Android-RWKV-MIDI)]
-19. Use RWKV to generate symbolic music to a text file. [[project](https://github.com/patchbanks/RWKV-v4-MIDI)]
-20. Use the RWKV-4 music model to generate the texture and music [[project](https://github.com/agreene5/Procedural-Purgatory)]
 
 ### Natural Language Understanding
 
@@ -149,7 +149,7 @@ Related projects:
 10. A comprehensive mobile application based on RWKV [[project](https://github.com/khhaliil/AVATARIO)]
 11. Knowledge graph extraction tool based on RWKV [[project](https://github.com/Ojiyumm/rwkv_kg)]
 
-### Other NLP tasks
+### Other NLP Tasks
 
 1. Multi-scale rwkv with 2-dimensional temporal convolutional network for short-term photovoltaic power forecasting [[paper](https://www.sciencedirect.com/science/article/abs/pii/S0360544224028433)]
 2. Contrastive learning for clinical outcome prediction with partial data sources [[paper](https://pmc.ncbi.nlm.nih.gov/articles/PMC11326519/)]
@@ -164,14 +164,13 @@ Related projects:
 11. Temporal and interactive modeling for efficient human-human motion generation [[paper](https://arxiv.org/abs/2408.17135)]
 12. Rrwkv: capturing long-range dependencies in rwkv [[paper](https://arxiv.org/abs/2306.05176)]
 13. Lkpnr: Large language models and knowledge graph for personalized news recommendation framework [[paper](https://search.ebscohost.com/login.aspx?direct=true&profile=ehost&scope=site&authtype=crawler&jrnl=15462218&AN=178256380&h=mPC2JIgqSZw4phTzIrP%2FKqjs9uCWP6JzGqQAI5ecEQmASbdVuYmY%2BQ17K27Xqqb%2BBbDDdbl%2F6scZRZNvhqBfCg%3D%3D&crl=c)]
-14. Why perturbing symbolic music is necessary: Fitting the distribution of never-used notes through a joint probabilistic diffusion model [[paper](https://arxiv.org/abs/2408.01950)]
-15. Optimizing robotic manipulation with decision-rwkv: A recurrent sequence modeling approach for lifelong learning [[paper](https://arxiv.org/abs/2408.01950)]
-16. Prosg: Using prompt synthetic gradients to alleviate prompt forgetting of rnn-like language models [[paper](https://arxiv.org/abs/2311.01981)]
-17. Spikegpt: Generative pre-trained language model with spiking neural networks [[paper](https://arxiv.org/abs/2302.13939)]
-18. General population projection model with census population data [[paper](https://scholarworks.lib.csusb.edu/etd/1803/)]
-19. Enhancing transformer rnns with multiple temporal perspectives [[paper](https://arxiv.org/abs/2402.02625)]
-20. Sensorimotor attention and language-based regressions in shared latent variables for integrating robot motion learning and llm [[paper](https://arxiv.org/abs/2407.09044)]
-21. A transfer learning-based training approach for dga classification [[paper](https://link.springer.com/chapter/10.1007/978-3-031-64171-8_20)]
+14. Optimizing robotic manipulation with decision-rwkv: A recurrent sequence modeling approach for lifelong learning [[paper](https://arxiv.org/abs/2408.01950)]
+15. Prosg: Using prompt synthetic gradients to alleviate prompt forgetting of rnn-like language models [[paper](https://arxiv.org/abs/2311.01981)]
+16. Spikegpt: Generative pre-trained language model with spiking neural networks [[paper](https://arxiv.org/abs/2302.13939)]
+17. General population projection model with census population data [[paper](https://scholarworks.lib.csusb.edu/etd/1803/)]
+18. Enhancing transformer rnns with multiple temporal perspectives [[paper](https://arxiv.org/abs/2402.02625)]
+19. Sensorimotor attention and language-based regressions in shared latent variables for integrating robot motion learning and llm [[paper](https://arxiv.org/abs/2407.09044)]
+20. A transfer learning-based training approach for dga classification [[paper](https://link.springer.com/chapter/10.1007/978-3-031-64171-8_20)]
 
 ### Computer Vision
 
@@ -195,6 +194,19 @@ Related projects:
 18. Exploring real&synthetic dataset and linear attention in image restoration [[paper](https://arxiv.org/abs/2412.03814)]
 19. Facial Expression Recognition with RWKV Architecture [[project](https://github.com/lukasVierling/FaceRWKV)]
 20. Image denoising model based on rwkv [[project](https://github.com/lll143653/rwkv-denoise)]
+
+### Audio and Music Tasks
+
+1. Android RWKV MIDI [[project](https://github.com/ZTMIDGO/Android-RWKV-MIDI)]
+2. Use RWKV to generate symbolic music to a text file. [[project](https://github.com/patchbanks/RWKV-v4-MIDI)]
+3. Use the RWKV-4 music model to generate the texture and music [[project](https://github.com/agreene5/Procedural-Purgatory)]
+4. Exploring rwkv for memory efficient and low latency streaming asr [[paper](https://arxiv.org/abs/2309.14758)]
+5. Speech missions with frozen RWKV language models [[project](https://github.com/AGENDD/RWKV-ASR)]
+6. AudioRWKV: Pretrained Audio RWKV for Audio Pattern Recognition [[project](https://github.com/diggerdu/AudioRWKV)]
+7. Why perturbing symbolic music is necessary: Fitting the distribution of never-used notes through a joint probabilistic diffusion model [[paper](https://arxiv.org/abs/2408.01950)]
+8. RWKV Based Music Generator [[project](https://github.com/asuller/RWKV-MusicGenerator)]
+9. Music Genre Classification RWKV [[project](https://github.com/AverageJoe9/Music-Genre-Classification-RWKV)]
+10. Advancing vad systems based on multi-task learning with improved model structures [[paper](https://arxiv.org/abs/2312.14860)]
 
 ### Web Application
 
@@ -220,30 +232,31 @@ In this paper, we have assembled 17 benchmark tests, each highlighting distinct 
 
 **NOTE:** We may miss some evaluations. Your suggestions are highly welcomed!
 
-| Benchmark   | Focus                              |
-|-------------|------------------------------------|
-|BIPIA [[paper](https://arxiv.org/abs/2312.14197)] |Indirect prompt injection attacks|
-|CoDI-Eval [[paper](https://ojs.aaai.org/index.php/AAAI/article/view/29734)] |The capability of LLMs to respond to the constraints in instructions.|
-|CMATH [[paper](https://arxiv.org/abs/2306.16636)] |Mathematical problem solving|
-|VasE [[paper](https://arxiv.org/abs/2312.03121)] |Evaluation through voting theory framework|
-|Head-to-Tail [[paper](https://arxiv.org/abs/2308.10168)] |Assess the ability of LLMs to internalize facts|
-|REGBENCH [[paper](https://arxiv.org/abs/2401.12973)] |In-context Language Learning(ICLL)|
-|Freshbench [[paper](https://arxiv.org/abs/2405.08460)] |A dynamic assessment framework for temporal generalisation|
-|LongctxBench [[paper](https://arxiv.org/abs/2407.01527)] |Efficiency in handling long contexts|
-|LongICLBench [[paper](https://arxiv.org/abs/2404.02060)] |Benchmark for extreme-label classification in long contexts|
-|LooGLE [[paper](https://arxiv.org/abs/2311.04939)] |Benchmark for long-dependency understanding.|
-|MAGNIFICO [[paper](https://arxiv.org/abs/2310.11634)] |Learning new interpretations in-context.|
-|MANGO [[paper](https://arxiv.org/abs/2403.19913)] |Benchmark for mapping and navigation capabilities.|
-|PRE [[paper](https://arxiv.org/abs/2401.15641)] |Evaluation framework inspired by academic peer review.|
-|RULER [[paper](https://arxiv.org/abs/2404.06654)] |Enhanced benchmark for long-context evaluations extending the NIAH test.|
-|S3EVAL [[paper](https://arxiv.org/abs/2310.15147)] |Flexible evaluation method using complex synthetic tasks.|
-|SuperCLUE [[paper](https://arxiv.org/abs/2307.15020)] |Comprehensive benchmark for Chinese user preferences.|
-|Zhujiu [[paper](https://arxiv.org/abs/2308.14353)] |Multi-dimensional evaluation benchmark for Chinese LLMs.|
+| Benchmark                                                                   | Focus                                                                    |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| BIPIA [[paper](https://arxiv.org/abs/2312.14197)]                           | Indirect prompt injection attacks                                        |
+| CoDI-Eval [[paper](https://ojs.aaai.org/index.php/AAAI/article/view/29734)] | The capability of LLMs to respond to the constraints in instructions.    |
+| CMATH [[paper](https://arxiv.org/abs/2306.16636)]                           | Mathematical problem solving                                             |
+| VasE [[paper](https://arxiv.org/abs/2312.03121)]                            | Evaluation through voting theory framework                               |
+| Head-to-Tail [[paper](https://arxiv.org/abs/2308.10168)]                    | Assess the ability of LLMs to internalize facts                          |
+| REGBENCH [[paper](https://arxiv.org/abs/2401.12973)]                        | In-context Language Learning(ICLL)                                       |
+| Freshbench [[paper](https://arxiv.org/abs/2405.08460)]                      | A dynamic assessment framework for temporal generalisation               |
+| LongctxBench [[paper](https://arxiv.org/abs/2407.01527)]                    | Efficiency in handling long contexts                                     |
+| LongICLBench [[paper](https://arxiv.org/abs/2404.02060)]                    | Benchmark for extreme-label classification in long contexts              |
+| LooGLE [[paper](https://arxiv.org/abs/2311.04939)]                          | Benchmark for long-dependency understanding.                             |
+| MAGNIFICO [[paper](https://arxiv.org/abs/2310.11634)]                       | Learning new interpretations in-context.                                 |
+| MANGO [[paper](https://arxiv.org/abs/2403.19913)]                           | Benchmark for mapping and navigation capabilities.                       |
+| PRE [[paper](https://arxiv.org/abs/2401.15641)]                             | Evaluation framework inspired by academic peer review.                   |
+| RULER [[paper](https://arxiv.org/abs/2404.06654)]                           | Enhanced benchmark for long-context evaluations extending the NIAH test. |
+| S3EVAL [[paper](https://arxiv.org/abs/2310.15147)]                          | Flexible evaluation method using complex synthetic tasks.                |
+| SuperCLUE [[paper](https://arxiv.org/abs/2307.15020)]                       | Comprehensive benchmark for Chinese user preferences.                    |
+| Zhujiu [[paper](https://arxiv.org/abs/2308.14353)]                          | Multi-dimensional evaluation benchmark for Chinese LLMs.                 |
 
-**Other evaluations**
+**Other Evaluations**
+
 1. Is attention required for icl? exploring the relationship between model architecture and in-context learning ability [[paper](https://openreview.net/forum?id=Qwq4cpLtoX)]
 2. Revenge of the fallen? recurrent models match transformers at predicting human language comprehension metrics [[paper](https://arxiv.org/abs/2404.19178)]
-3. Veliki jezikovni modeli so strojni ucenci v casu sklepanja [[paper](https://erk.fe.uni-lj.si/2023/papers/grm(veliki_jezikovni).pdf)]
+3. Veliki jezikovni modeli so strojni ucenci v casu sklepanja [[paper](<https://erk.fe.uni-lj.si/2023/papers/grm(veliki_jezikovni).pdf>)]
 4. Benchmarking neural decoding backbones towards enhanced on-edge ibci applications [[paper](https://arxiv.org/abs/2406.06626)]
 5. Does transformer interpretability transfer to rnns? [[paper](https://arxiv.org/abs/2404.05971)]
 6. From words to numbers: Your large language model is secretly a capable regressor when given in-context examples [[paper](https://arxiv.org/abs/2404.07544)]
@@ -255,60 +268,54 @@ In this paper, we have assembled 17 benchmark tests, each highlighting distinct 
 
 ### Others
 
-1. Advancing vad systems based on multi-task learning with improved model structures [[paper](https://arxiv.org/abs/2312.14860)]
-2. Exploring rwkv for memory efficient and low latency streaming asr [[paper](https://arxiv.org/abs/2309.14758)]
-3. Spiking mixers for robust and energy-efficient vision-and-language learning [[paper](https://openreview.net/forum?id=FyZaVdQLdJ)]
-4. Visualrwkv: Exploring recurrent neural networks for visual language models [[paper](https://arxiv.org/abs/2406.13362)]
-5. A unified implicit attention formulation for gated-linear recurrent sequence models [[paper](https://arxiv.org/abs/2405.16504)]
-6. Modern sequence models in context of multi-agent reinforcement learning [[paper](https://epub.jku.at/obvulioa/urn/urn:nbn:at:at-ubl:1-81083)]
-7. Generative calibration for in-context learning [[paper](https://arxiv.org/abs/2310.10266)]
-8. Speech missions with frozen RWKV language models [[project](https://github.com/AGENDD/RWKV-ASR)]
-9. MiniRWKV-4 [[project](https://github.com/StarRing2022/MiniRWKV-4)]
-10. RAG system for RWKV [[project](https://github.com/AIIRWKV/RWKV-RAG)]
-11. Dlip-RWKV [[project](https://github.com/StarRing2022/Dlip-RWKV)]
-12. Project to extend the functionality of RWKV LM [[project](https://github.com/yynil/RWKV_LM_EXT)]
-13. AudioRWKV: Pretrained Audio RWKV for Audio Pattern Recognition [[project](https://github.com/diggerdu/AudioRWKV)]
-14. Reward Model based on RWKV [[project](https://github.com/Mazidad/rwkv-reward-enhanced)]
-15. RWKV Based Music Generator [[project](https://github.com/asuller/RWKV-MusicGenerator)]
-16. Music Genre Classification RWKV [[project](https://github.com/AverageJoe9/Music-Genre-Classification-RWKV)]
-17. RWKV Twitter Bot Detection Project [[project](https://github.com/Max-SF1/Bot-Ani-RWKV-twitter-bot-detection)]
-18. RWKV-PEFT [[project](https://github.com/JL-er/RWKV-PEFT) [project](https://github.com/Seikaijyu/RWKV-PEFT-Simple)]
-19. RWKV5-infctxLM [[project](https://github.com/JL-er/RWKV5-infctxLM)]
-20. DecisionRWKV  [[project](https://github.com/ancorasir/DecisionRWKV)]
-21. A 20M RWKV v6 can do nonogram [[project](https://github.com/LeC-Z/RWKV-nonogram)]
-22. RWKV for industrial time-series prediction [[project](https://github.com/ShixiangLi/RWKV_RUL)]
-23. TrainChatGalRWKV [[project](https://github.com/SynthiaDL/TrainChatGalRWKV)]
-24. Tinyrwkv: A tinier port of RWKV-LM [[project](https://github.com/wozeparrot/tinyrwkv)]
-25. RWKV LLM servicer for SimpleAI [[project](https://github.com/Nintorac/simple_rwkv)]
-26. A RWKV management and startup tool [[project](https://github.com/josStorer/RWKV-Runner)]
-27. Llama-node: Node.js Library for Large Language Model [[project](https://github.com/Atome-FE/llama-node)]
-28. RWKV godot interface module [[project](https://github.com/harrisonvanderbyl/godot-rwkv)]
-29. HF for RWKVRaven Alpaca [[project](https://github.com/StarRing2022/HF-For-RWKVRaven-Alpaca)]
-30. HF for RWKVWorld LoraAlpaca [[project](https://github.com/StarRing2022/HF-For-RWKVWorld-LoraAlpaca)]
-31. Training a reward model for RLHF using RWKV [[project](https://github.com/jiamingkong/rwkv_reward)]
-32. Attempt to use RWKV to achieve infinite context length for decision-making [[project](https://github.com/typoverflow/Decision-RWKV)]
-33. Reinforcement Learning Toolkit for RWKV [[project](https://github.com/OpenMOSE/RWKV-LM-RLHF)]
-34. State tuning with Orpo of RWKV v6 can be performed with 4-bit quantization [[project](https://github.com/OpenMOSE/RWKV-LM-State-4bit-Orpo)]
-35. Fine Tuning RWKV [[project](https://github.com/Durham/RWKV-finetune-script)]
-36. LoRA fork of RWKV-LM [[project](https://github.com/if001/RWKV-LM-LoRA-ja)]
-37. A Lightweight and Extensible RWKV API for Inference [[project](https://github.com/ssg-qwq/RWKV-Light-API)]
-38. RWKV StateTuning [[project](https://github.com/Jellyfish042/RWKV-StateTuning)]
-39. Continous batching and parallel acceleration for RWKV6 [[project](https://github.com/00ffcc/chunkRWKV6)]
-40. RWKV-LM interpretability research [[project](https://github.com/UnstoppableCurry/RWKV-LM-Interpretability-Research)]
-41. Web-RWKV Inspector [[project](https://github.com/cryscan/web-rwkv-inspector)]
-42. RWKV-UMAP: Recording and visualizing transitions of RWKV-LM internal states [[project](https://github.com/Prunoideae/rwkv_umap)]
-43. A converter and basic tester for rwkv onnx [[project](https://github.com/Dan-wanna-M/rwkv-tensorrt)]
-44. Llama and other large language models on iOS and MacOS offline using GGML library [[project](https://github.com/guinmoon/LLMFarm)]
-45. Enhancing LangChain prompts to work better with RWKV models [[project](https://github.com/jiamingkong/RWKV_chains)]
-46. Visual server for RWKV-Ouroboros project [[project](https://github.com/neromous/RWKV-Ouroboros-app)]
-47. A set of bash scripts to automate deployment of RWKV modelswith the use of KoboldCpp on Android - Termux [[project](https://github.com/latestissue/AltaeraAI)]
-48. Distill (hybrid) RWKV model with Llama [[project](https://github.com/yynil/RWKVinLLAMA)]
-49. GPTQ for RWKV [[project](https://github.com/3outeille/GPTQ-for-RWKV)]
-50. Transplant the RWKV-LM to ROCm platform [[project](https://github.com/Alic-Li/RWKV-LM-AMD-Radeon-ROCm-hip)]
-51. A deep learning engine that can be built into your video game [[project](https://github.com/SingingRivulet/InnerDNN)]
-52. EasyChat Q&A System [[project](https://github.com/Ow1onp/EasyChat-Server)]
-53. ChatRWKV PC [[project](https://github.com/mosterwei13/ChatRWKV_PC)]
-54. PlantFlower Datasets: Based on the RWKV World model dataset [[project](https://github.com/lovebull/PlantFlowerDatasets)]
+2. Spiking mixers for robust and energy-efficient vision-and-language learning [[paper](https://openreview.net/forum?id=FyZaVdQLdJ)]
+3. Visualrwkv: Exploring recurrent neural networks for visual language models [[paper](https://arxiv.org/abs/2406.13362)]
+4. A unified implicit attention formulation for gated-linear recurrent sequence models [[paper](https://arxiv.org/abs/2405.16504)]
+5. Modern sequence models in context of multi-agent reinforcement learning [[paper](https://epub.jku.at/obvulioa/urn/urn:nbn:at:at-ubl:1-81083)]
+6. Generative calibration for in-context learning [[paper](https://arxiv.org/abs/2310.10266)]
+7. MiniRWKV-4 [[project](https://github.com/StarRing2022/MiniRWKV-4)]
+8. RAG system for RWKV [[project](https://github.com/AIIRWKV/RWKV-RAG)]
+9. Dlip-RWKV [[project](https://github.com/StarRing2022/Dlip-RWKV)]
+10. Project to extend the functionality of RWKV LM [[project](https://github.com/yynil/RWKV_LM_EXT)]
+11. Reward Model based on RWKV [[project](https://github.com/Mazidad/rwkv-reward-enhanced)]
+12. RWKV Twitter Bot Detection Project [[project](https://github.com/Max-SF1/Bot-Ani-RWKV-twitter-bot-detection)]
+13. RWKV-PEFT [[project](https://github.com/JL-er/RWKV-PEFT) [project](https://github.com/Seikaijyu/RWKV-PEFT-Simple)]
+14. RWKV5-infctxLM [[project](https://github.com/JL-er/RWKV5-infctxLM)]
+15. DecisionRWKV [[project](https://github.com/ancorasir/DecisionRWKV)]
+16. A 20M RWKV v6 can do nonogram [[project](https://github.com/LeC-Z/RWKV-nonogram)]
+17. RWKV for industrial time-series prediction [[project](https://github.com/ShixiangLi/RWKV_RUL)]
+18. TrainChatGalRWKV [[project](https://github.com/SynthiaDL/TrainChatGalRWKV)]
+19. Tinyrwkv: A tinier port of RWKV-LM [[project](https://github.com/wozeparrot/tinyrwkv)]
+20. RWKV LLM servicer for SimpleAI [[project](https://github.com/Nintorac/simple_rwkv)]
+21. A RWKV management and startup tool [[project](https://github.com/josStorer/RWKV-Runner)]
+22. Llama-node: Node.js Library for Large Language Model [[project](https://github.com/Atome-FE/llama-node)]
+23. RWKV godot interface module [[project](https://github.com/harrisonvanderbyl/godot-rwkv)]
+24. HF for RWKVRaven Alpaca [[project](https://github.com/StarRing2022/HF-For-RWKVRaven-Alpaca)]
+25. HF for RWKVWorld LoraAlpaca [[project](https://github.com/StarRing2022/HF-For-RWKVWorld-LoraAlpaca)]
+26. Training a reward model for RLHF using RWKV [[project](https://github.com/jiamingkong/rwkv_reward)]
+27. Attempt to use RWKV to achieve infinite context length for decision-making [[project](https://github.com/typoverflow/Decision-RWKV)]
+28. Reinforcement Learning Toolkit for RWKV [[project](https://github.com/OpenMOSE/RWKV-LM-RLHF)]
+29. State tuning with Orpo of RWKV v6 can be performed with 4-bit quantization [[project](https://github.com/OpenMOSE/RWKV-LM-State-4bit-Orpo)]
+30. Fine Tuning RWKV [[project](https://github.com/Durham/RWKV-finetune-script)]
+31. LoRA fork of RWKV-LM [[project](https://github.com/if001/RWKV-LM-LoRA-ja)]
+32. A Lightweight and Extensible RWKV API for Inference [[project](https://github.com/ssg-qwq/RWKV-Light-API)]
+33. RWKV StateTuning [[project](https://github.com/Jellyfish042/RWKV-StateTuning)]
+34. Continous batching and parallel acceleration for RWKV6 [[project](https://github.com/00ffcc/chunkRWKV6)]
+35. RWKV-LM interpretability research [[project](https://github.com/UnstoppableCurry/RWKV-LM-Interpretability-Research)]
+36. Web-RWKV Inspector [[project](https://github.com/cryscan/web-rwkv-inspector)]
+37. RWKV-UMAP: Recording and visualizing transitions of RWKV-LM internal states [[project](https://github.com/Prunoideae/rwkv_umap)]
+38. A converter and basic tester for rwkv onnx [[project](https://github.com/Dan-wanna-M/rwkv-tensorrt)]
+39. Llama and other large language models on iOS and MacOS offline using GGML library [[project](https://github.com/guinmoon/LLMFarm)]
+40. Enhancing LangChain prompts to work better with RWKV models [[project](https://github.com/jiamingkong/RWKV_chains)]
+41. Visual server for RWKV-Ouroboros project [[project](https://github.com/neromous/RWKV-Ouroboros-app)]
+42. A set of bash scripts to automate deployment of RWKV modelswith the use of KoboldCpp on Android - Termux [[project](https://github.com/latestissue/AltaeraAI)]
+43. Distill (hybrid) RWKV model with Llama [[project](https://github.com/yynil/RWKVinLLAMA)]
+44. GPTQ for RWKV [[project](https://github.com/3outeille/GPTQ-for-RWKV)]
+45. Transplant the RWKV-LM to ROCm platform [[project](https://github.com/Alic-Li/RWKV-LM-AMD-Radeon-ROCm-hip)]
+46. A deep learning engine that can be built into your video game [[project](https://github.com/SingingRivulet/InnerDNN)]
+47. EasyChat Q&A System [[project](https://github.com/Ow1onp/EasyChat-Server)]
+48. ChatRWKV PC [[project](https://github.com/mosterwei13/ChatRWKV_PC)]
+49. PlantFlower Datasets: Based on the RWKV World model dataset [[project](https://github.com/lovebull/PlantFlowerDatasets)]
 
 ## Contributing
 
@@ -323,9 +330,10 @@ You can also open an issue if you have anything to add or comment.
 ## Citation
 
 If you find this project useful in your research or work, please consider citing it:
+
 ```
 @article{li2024survey,
-      title={A Survey of RWKV}, 
+      title={A Survey of RWKV},
       author={Li, Zhiyuan and Xia, Tingyu and Chang, Yi and Wu, Yuan},
       journal={arXiv preprint arXiv:2412.14847},
       year={2024}


### PR DESCRIPTION
Hello, thank you for compiling this repository of RWKV-related projects! This small PR does the following:
1. Moves audio and music tasks to a separate section, where previously they had been scattered around;
2. Updates that section with a new project, RWKV-SpeechChat; and
3. Fixes some minor typographical errors (e.g. repositorie -> repository).

I think audio and music tasks deserve their own category, even if the content within it is diverse (speech recognition to MIDI modeling). Previously MIDI tasks were considered natural language tasks, which did not feel right to me. Please let me know what you think.